### PR TITLE
Support Gradle 6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ allprojects {
         version = rootProject.version
         packageName = rootProject.group
         clsName = 'BuildConfig'
-        buildConfigField 'String[]', 'SUPPORTED_GRADLE_VERSIONS', '{"4.6", "4.5", "4.4", "4.3", "4.2", "4.1", "4.0"}'
+        buildConfigField 'String[]', 'TESTED_GRADLE_VERSIONS', '{"4.9", "5.6.4", "6.0"}'
     }
 
     repositories {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-all.zip

--- a/plugin-test/src/test/kotlin/BuildingTest.kt
+++ b/plugin-test/src/test/kotlin/BuildingTest.kt
@@ -9,7 +9,7 @@ import java.io.PrintWriter
 import java.util.*
 
 object BuildingTest : Spek({
-    BuildConfig.SUPPORTED_GRADLE_VERSIONS.forEach { gradleVersion ->
+    BuildConfig.TESTED_GRADLE_VERSIONS.forEach { gradleVersion ->
         describe("project with gradle version $gradleVersion") {
             val folder by temporaryFolder()
 

--- a/plugin-test/src/test/kotlin/DownloadInParallelTest.kt
+++ b/plugin-test/src/test/kotlin/DownloadInParallelTest.kt
@@ -8,7 +8,7 @@ import java.io.FileWriter
 import java.io.PrintWriter
 
 object DownloadInParallelTest : Spek({
-    BuildConfig.SUPPORTED_GRADLE_VERSIONS.forEach { gradleVersion ->
+    BuildConfig.TESTED_GRADLE_VERSIONS.forEach { gradleVersion ->
         describe("project with gradle version $gradleVersion") {
             val folder by temporaryFolder()
 

--- a/plugin-test/src/test/kotlin/FallbackTest.kt
+++ b/plugin-test/src/test/kotlin/FallbackTest.kt
@@ -7,7 +7,7 @@ import java.io.FileWriter
 import java.io.PrintWriter
 
 object FallbackTest : Spek({
-    BuildConfig.SUPPORTED_GRADLE_VERSIONS.forEach { gradleVersion ->
+    BuildConfig.TESTED_GRADLE_VERSIONS.forEach { gradleVersion ->
         describe("project with gradle version $gradleVersion") {
             val folder by temporaryFolder()
 

--- a/plugin-test/src/test/kotlin/MirakleInitTest.kt
+++ b/plugin-test/src/test/kotlin/MirakleInitTest.kt
@@ -10,7 +10,7 @@ import java.util.*
 import kotlin.test.assertTrue
 
 object MirakleInitTest : Spek({
-    BuildConfig.SUPPORTED_GRADLE_VERSIONS.forEach { gradleVersion ->
+    BuildConfig.TESTED_GRADLE_VERSIONS.forEach { gradleVersion ->
         describe("project with gradle version $gradleVersion") {
             val folder by temporaryFolder()
 

--- a/plugin-test/src/test/kotlin/StartParametersTest.kt
+++ b/plugin-test/src/test/kotlin/StartParametersTest.kt
@@ -6,7 +6,7 @@ import org.jetbrains.spek.api.dsl.*
 import java.io.*
 
 object StartParametersTest : Spek({
-    BuildConfig.SUPPORTED_GRADLE_VERSIONS.forEach { gradleVersion ->
+    BuildConfig.TESTED_GRADLE_VERSIONS.forEach { gradleVersion ->
         describe("project with gradle version $gradleVersion") {
             val folder by temporaryFolder()
 

--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -258,13 +258,11 @@ val booleanParamsToOption = listOf(
         StartParameter::isRefreshDependencies to "--refresh-dependencies",
         StartParameter::isContinueOnFailure to "--continue",
         StartParameter::isOffline to "--offline",
-        StartParameter::isRecompileScripts to "--recompile-scripts",
         StartParameter::isParallelProjectExecutionEnabled to "--parallel",
         StartParameter::isConfigureOnDemand to "--configure-on-demand"
 )
 
 val negativeBooleanParamsToOption = listOf(
-        StartParameter::isSearchUpwards to "--no-search-upward",
         StartParameter::isBuildProjectDependencies to "--no-rebuild"
 )
 


### PR DESCRIPTION
Remove deprecated start parameters and add Gradle 6.0 as test target.
#24 