### PR TITLE
Android studio version property fix

### DIFF
--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -271,7 +271,8 @@ val negativeBooleanParamsToOption = listOf(
 )
 
 val excludedProjectProperties = listOf(
-        "android.injected.attribution.file.location" // disable Android Studio Build Analyzer collection on remote machine
+        "android.injected.attribution.file.location", // disable Android Studio Build Analyzer collection on remote machine
+        "android.injected.studio.version" // disable Android Studio version
 )
 
 val logLevelToOption = listOf(


### PR DESCRIPTION
This PR fixes the issue https://github.com/Instamotor-Labs/mirakle/issues/38

The problem is due to `--project-prop, android.injected.studio.version=10.4.1 Beta 1`. It contains whitespaces and breaks the plugin. 
It seems safe to ignore this property.