### PR TITLE
Pass GRADLE_USER_HOME/gradle.properties and PROJECT_DIR/mirakle.properties to remote build.

### DIFF
--- a/plugin-test/src/test/kotlin/StartParametersTest.kt
+++ b/plugin-test/src/test/kotlin/StartParametersTest.kt
@@ -225,8 +225,13 @@ object StartParametersTest : Spek({
                         setProperty("systemProp.prop4", "4_COLLISION")
                         setProperty("prop4", "4")
                         setProperty("systemProp.prop5", "5")
+                        setProperty("prop6", "6")
                     }.store(outputStream(), null)
                 }
+
+                val gradleRunnerWithProperties = gradleRunner.addArgs(
+                        listOf("--system-prop", "prop2=22", "--project-prop", "prop6=66")
+                )
 
                 it("should receive properties") {
                     buildFileWriter().use {
@@ -234,7 +239,8 @@ object StartParametersTest : Spek({
                                 mapOf(
                                         "prop1" to "1",
                                         "prop3" to "3",
-                                        "prop4" to "4"
+                                        "prop4" to "4",
+                                        "prop6" to "66"
                                 )
                         ))
 
@@ -247,7 +253,7 @@ object StartParametersTest : Spek({
                         ))
                     }
 
-                    gradleRunner
+                    gradleRunnerWithProperties
                             .withTestKitDir(gradleHomeFolder.root)
                             .build()
                 }


### PR DESCRIPTION
#56 

Parse and pass `GRADLE_USER_HOME/gradle.properties` as `--project-prop` and `--system-prop` command line arguments to remote build.

Introduce `PROJECT_DIR/mirakle.properties` and `PROJECT_DIR/mirakle_local.properties` which can be used to pass specific gradle arguments to remote build or override existing arguments. Gradle properties from that files have highest priority over all other properties. Both files serves the same purpose, but `mirakle_local.properties` may be used for user specific values and skipped from commiting to VCS.