### PR TITLE
Fix rsync arguments concatenation

### DIFF
--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -98,7 +98,7 @@ open class Mirakle : Plugin<Gradle> {
                             "ssh ${config.sshArgs.joinToString(separator = " ")}",
                             "--exclude=mirakle.gradle"
                     )
-                    args(config.rsyncToRemoteArgs)
+                    args(config.buildRsyncToRemoteArgs())
                 }
 
                 val execute = project.task<Exec>("executeOnRemote") {
@@ -144,7 +144,7 @@ open class Mirakle : Plugin<Gradle> {
                             "ssh ${config.sshArgs.joinToString(separator = " ")}",
                             "--exclude=mirakle.gradle"
                     )
-                    args(config.rsyncFromRemoteArgs)
+                    args(config.buildRsyncFromRemoteArgs())
                 }.mustRunAfter(execute) as Exec
 
                 if (config.downloadInParallel) {
@@ -362,13 +362,11 @@ open class MirakleExtension {
             "--archive",
             "--delete"
     )
-        get() = field.plus(excludeLocal.plus(excludeCommon).map { "--exclude=$it" })
 
     var rsyncFromRemoteArgs = setOf(
             "--archive",
             "--delete"
     )
-        get() = field.plus(excludeRemote.plus(excludeCommon).map { "--exclude=$it" })
 
     var sshArgs = emptySet<String>()
 
@@ -378,6 +376,15 @@ open class MirakleExtension {
     var downloadInterval = 2000L
 
     var breakOnTasks = emptySet<String>()
+
+    fun buildRsyncToRemoteArgs(): Set<String> =
+        rsyncToRemoteArgs + excludeLocal.mapToRsyncExcludeArgs()
+
+    fun buildRsyncFromRemoteArgs(): Set<String> =
+        rsyncFromRemoteArgs + excludeRemote.mapToRsyncExcludeArgs()
+
+    private fun Set<String>.mapToRsyncExcludeArgs(): Set<String> =
+        this.plus(excludeCommon).map { "--exclude=$it" }.toSet()
 }
 
 fun startParamsToArgs(params: StartParameter) = with(params) {

--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -377,10 +377,10 @@ open class MirakleExtension {
 
     var breakOnTasks = emptySet<String>()
 
-    fun buildRsyncToRemoteArgs(): Set<String> =
+    internal fun buildRsyncToRemoteArgs(): Set<String> =
         rsyncToRemoteArgs + excludeLocal.mapToRsyncExcludeArgs()
 
-    fun buildRsyncFromRemoteArgs(): Set<String> =
+    internal fun buildRsyncFromRemoteArgs(): Set<String> =
         rsyncFromRemoteArgs + excludeRemote.mapToRsyncExcludeArgs()
 
     private fun Set<String>.mapToRsyncExcludeArgs(): Set<String> =


### PR DESCRIPTION
This fixes the configuration issue I've experienced. 

### Explanation:
In the current version, we need to keep the order of configuration parameters to prevent unexpected collision of exclusion patterns.

Look at this:
```groovy
 mirakle {
    host "host"

    rsyncToRemoteArgs += ["--info=progress2"] 
    rsyncFromRemoteArgs += ["--info=progress2"]

    excludeCommon = [".gradle", ".idea", "**/local.properties", "**/mirakle.properties", "**/mirakle_local.properties"]
}
```
There I want to use my own patterns in `excludeCommon`. The difference from the default one is that the `"**/.git/"` pattern is absent. But it won't work as in code we capture ([There](https://github.com/Adambl4/mirakle/blob/4aa593c8b5d034b38002b4e96df6fddda50f065b/plugin/src/main/kotlin/Mirakle.kt#L365) and [there](https://github.com/Adambl4/mirakle/blob/4aa593c8b5d034b38002b4e96df6fddda50f065b/plugin/src/main/kotlin/Mirakle.kt#L371)) the default value when we accessing the `rsyncToRemoteArgs` and `rsyncFromRemoteArgs`. After using the `plusAssign` operator it will fill rsync argument sets with exclusions from both lists and future changes to `excludeCommon` (or `excludeRemote` and `excludeLocal`) will be ignored.

We can easily fix it by changing the order of our parameters like this:
```groovy
 mirakle {
    host "host"

    excludeCommon = [".gradle", ".idea", "**/local.properties", "**/mirakle.properties", "**/mirakle_local.properties"]

    rsyncToRemoteArgs += ["--info=progress2"] 
    rsyncFromRemoteArgs += ["--info=progress2"]
}
```
This way allows us to change the content of `excludeCommon` set and it will be handled properly cause we move concatenation down.

### What should be done

The easy fix is not acceptable as it isn't obvious at all. I've separated desired concatenation from values declaration - now we have functions to do it. These guarantee us that we won't make any unpredicted concatenations in configuration time.