### PR TITLE
Remove AbstractTask usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
 
     buildConfig {
         buildConfigField "String", "VERSION", "\"${rootProject.version}\""
-        buildConfigField 'List<String>', 'TESTED_GRADLE_VERSIONS', 'listOf("6.5", "6.6", "6.7.1", "7.0")'
+        buildConfigField 'List<String>', 'TESTED_GRADLE_VERSIONS', 'listOf("6.5", "6.6", "6.7.1", "7.0", "7.2")'
     }
 
     repositories {

--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -7,7 +7,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Task
 import org.gradle.api.execution.TaskExecutionListener
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.logging.configuration.ConsoleOutput
@@ -150,7 +149,7 @@ open class Mirakle : Plugin<Gradle> {
                 if (config.downloadInParallel) {
                     if (config.downloadInterval <= 0) throw MirakleException("downloadInterval must be >0")
 
-                    val downloadInParallel = project.task<AbstractTask>("downloadInParallel") {
+                    val downloadInParallel = project.task<Task>("downloadInParallel") {
                         doFirst {
                             val downloadExecAction = services.get(ExecActionFactory::class.java).newExecAction().apply {
                                 commandLine = download.commandLine


### PR DESCRIPTION
Failing on Gradle 7.2 with:
```
Cannot create task ':downloadInParallel' of type 'AbstractTask' as this type is not supported for task registration.
```

after https://github.com/gradle/gradle/pull/12830