### PR TITLE
Adding a new parameter to be able to configure the ssh client

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ mirakle {
 | rsyncToRemoteArgs  |  `["--archive", "--delete"]`  | Set of rsync arguments that are used when rsync uploads files to remote machine.  |  
 | rsyncFromRemoteArgs  |  `["--archive", "--delete"]` | Set of rsync arguments that are used when rsync downloads files from remote machine.  |
 | sshArgs  |  `[]` | Set of ssh arguments that are used to establish connection with remote machine. |   
-| fallback  | `false`  | If set true mirakle will execute build on local machine when upload to remote failed.  |  
+| sshClient  |  `ssh` | Ssh client implementation, for example Teleport ssh. |
+| fallback  | `false`  | If set true mirakle will execute build on local machine when upload to remote failed.  |
 | downloadInParallel  | `false`  | If set true mirakle will constantly fetch new files from remote machine during "executeOnRemote" phase of build. May result to reduction of total build time.      | 
 | downloadInterval  | `2000`  | Download in parallel interval in mills.  | 
 | breakOnTasks  | `[]`  |  Set of regex patterns of tasks on which remote build should be finished and continued on local machine. [May result in speeding up Android builds.](https://github.com/Adambl4/mirakle/blob/development/docs/TIPS_AND_TRICKS.md#speed-up-android-build-by-breaking-remote-execution-on-package-task)      |

--- a/plugin-test/src/test/kotlin/MainframerConfigTest.kt
+++ b/plugin-test/src/test/kotlin/MainframerConfigTest.kt
@@ -27,7 +27,9 @@ object MainframerConfigTest: Spek({
                 assertTrue(config.excludeCommon.isEmpty())
                 assertTrue(config.excludeLocal.isEmpty())
                 assertTrue(config.excludeRemote.isEmpty())
+
                 assertTrue(config.sshArgs.isEmpty())
+                assertEquals("ssh", config.sshClient)
 
                 assertEquals(setOf(
                         "--archive",

--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -139,7 +139,7 @@ open class Mirakle : Plugin<Gradle> {
                 }
 
                 val execute = project.task<Exec>("executeOnRemote") {
-                    setCommandLine("ssh")
+                    setCommandLine(config.sshClient)
                     args(config.sshArgs)
                     args(
                             config.host,
@@ -414,6 +414,8 @@ open class MirakleExtension {
 
     var sshArgs = emptySet<String>()
 
+    var sshClient = "ssh"
+
     var fallback = false
 
     var downloadInParallel = false
@@ -533,6 +535,7 @@ fun getMainframerConfigOrNull(projectDir: File, mirakleConfig: MirakleExtension)
             downloadInParallel = mirakleConfig.downloadInParallel
             downloadInterval = mirakleConfig.downloadInterval
             sshArgs = mirakleConfig.sshArgs
+            sshClient = mirakleConfig.sshClient
             breakOnTasks = mirakleConfig.breakOnTasks
         }
     }


### PR DESCRIPTION
Sometimes it can be useful to be able to choose a different ssh implementation, such as the one provided by [Teleport](https://goteleport.com/docs/server-access/guides/tsh/)

With this new parameter, `sshClient` it is able to configure mirakle to run using a different ssh client

For example:
```kotlin
mirakle {
    sshClient = "tsh"
    sshArgs += ["ssh"]  
}
```

Please let me know if you find interesting to add this parameter to the library or if you want me to do any change to the PR