### PR TITLE
Add support for dependency verification start params

### DIFF
--- a/plugin-test/src/test/kotlin/StartParametersTest.kt
+++ b/plugin-test/src/test/kotlin/StartParametersTest.kt
@@ -129,6 +129,42 @@ object StartParametersTest : Spek({
                 }
             }
 
+            describe("dependency verification start params") {
+                verificationModeToOption.onEach { (param, option) ->
+                    given("param ${param.name}") {
+                        on("passing $option") {
+
+                            buildFileWriter().use {
+                                it.write(ASSERT_START_PARAM_DEPENDENCY_VERIFICATION_MODE_IS(param.name))
+                            }
+
+                            it("should receive ${param.name}") {
+                                gradleRunner.addArgs(option.split(" ")[0], option.split(" ")[1]).build()
+                            }
+                        }
+                    }
+                }
+            }
+
+            describe("write dependency verifications start params") {
+                val writeDependencyVerificationModes = listOf(
+                        "sha256",
+                        "pgp",
+                        "sha256,pgp"
+                )
+                writeDependencyVerificationModes.onEach { mode ->
+                    on("mode $mode") {
+                        buildFileWriter().use {
+                            it.write(ASSERT_START_PARAM_WRITE_DEPENDENCY_VERIFICATION(mode))
+                        }
+
+                        it("should receive same $mode") {
+                            gradleRunner.addArgs("--write-verification-metadata $mode")
+                        }
+                    }
+                }
+            }
+
             on("passing tasks") {
                 val tasks = listOf("task1", "task2", "task3")
 

--- a/plugin-test/src/test/kotlin/utils.kt
+++ b/plugin-test/src/test/kotlin/utils.kt
@@ -280,6 +280,20 @@ val ASSERT_START_PARAM_CONSOLE_OUTPUT_IS = fun(enumName: String) =
             throw Exception("ConsoleOutput must be $enumName")
         """
 
+val ASSERT_START_PARAM_DEPENDENCY_VERIFICATION_MODE_IS = fun(enumName: String) =
+    """
+        if(project.gradle.startParameter.dependencyVerificationMode != DependencyVerificationMode.$enumName)
+            throw Exception("Dependency verification mode must be $enumName")
+        """
+
+val ASSERT_START_PARAM_WRITE_DEPENDENCY_VERIFICATION = fun(mode: String) =
+    """
+        if(project.gradle.startParameter.getWriteDependencyVerifications().join(',') != mode)
+            throw Exception("Write dependency verification mode must be $mode")
+        """
+
+
+
 val ASSERT_CONTAINS_TASKS = fun(tasks: List<String>) =
         """
         if(!gradle.startParameter.taskNames.containsAll(listOf(${tasks.joinToString { "\"$it\"" }})))

--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -6,6 +6,7 @@ import org.gradle.StartParameter
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Task
+import org.gradle.api.artifacts.verification.DependencyVerificationMode
 import org.gradle.api.execution.TaskExecutionListener
 import org.gradle.api.invocation.Gradle
 import org.gradle.api.logging.LogLevel
@@ -481,6 +482,8 @@ fun startParamsToArgs(params: StartParameter) = with(params) {
             .plus(logLevelToOption.firstOrNull { (level, _) -> logLevel == level }?.second)
             .plus(showStacktraceToOption.firstOrNull { (show, _) -> showStacktrace == show }?.second)
             .plus(consoleOutputToOption.firstOrNull { (console, _) -> consoleOutput == console }?.second)
+            .plus(verificationModeToOption.firstOrNull { (verificationMode, _) -> dependencyVerificationMode == verificationMode }?.second)
+            .plus(writeDependencyVerifications.joinToString(",").ifBlank { null }?.let { "$writeDependencyVerificationParam $it"})
             .filterNotNull()
 }
 
@@ -521,6 +524,16 @@ val consoleOutputToOption = listOf(
         //ConsoleOutput.Auto to "--console auto", //default, no need to pass
         ConsoleOutput.Rich to "--console rich"
 )
+
+// related to gradle dependency verification
+// https://docs.gradle.org/current/userguide/dependency_verification.html
+val verificationModeToOption = listOf(
+    DependencyVerificationMode.STRICT to "--dependency-verification strict",
+    DependencyVerificationMode.LENIENT to "--dependency-verification lenient",
+    DependencyVerificationMode.OFF to "--dependency-verification off"
+)
+
+const val writeDependencyVerificationParam = "--write-verification-metadata"
 
 //since build occurs on a remote machine, console output will contain remote directories
 //to let IDE and other tools properly parse the output, mirakle need to replace remote dir by local one


### PR DESCRIPTION
Gradle offers useful feature: [dependency verification](https://docs.gradle.org/current/userguide/dependency_verification.html) 

It writes sha256 checksum and pgp signature in `$PROJECT_ROOT/gradle/verification-metadata.xml`. After that every build fails if checksum or signature of dependency differs. 

This PR adds support for start params related to dependency verification: 
`--write-verification-metadata sha256|pgp`
and 
`-dependency-verification strict|lenient|off`
