### PR TITLE
Fix hostname error, utf-8 encoding

### DIFF
--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -394,6 +394,8 @@ open class ExecuteOnRemoteTask : Exec() {
         val remoteGradleCommand = "./gradlew -P$BUILD_ON_REMOTE=true $taskArgs"
         val remoteBashCommand = listOf(
             "set -e $additionalCommand",
+            "export LANG=C.UTF-8",
+            "export LC_CTYPE=C.UTF-8",
             "cd $remoteFolder",
             remoteGradleCommand
         ).joinToString(" && ")

--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -392,12 +392,16 @@ open class ExecuteOnRemoteTask : Exec() {
         val remoteFolder = "${config.remoteFolder}/${gradlewRoot.name}"
         val additionalCommand = config.remoteBashCommand?.ifBlank { null }?.let { "&& $it" } ?: ""
         val remoteGradleCommand = "./gradlew -P$BUILD_ON_REMOTE=true $taskArgs"
-        val remoteBashCommand = "echo 'set -e $additionalCommand && cd $remoteFolder && $remoteGradleCommand' | bash"
+        val remoteBashCommand = listOf(
+            "set -e $additionalCommand",
+            "cd $remoteFolder",
+            remoteGradleCommand
+        ).joinToString(" && ")
 
         setCommandLine(config.sshClient)
         args(config.sshArgs)
         args(config.host)
-        args(remoteBashCommand)
+        args("echo '$remoteBashCommand' | bash")
 
         super.exec()
     }

--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -392,7 +392,7 @@ open class ExecuteOnRemoteTask : Exec() {
         val remoteFolder = "${config.remoteFolder}/${gradlewRoot.name}"
         val additionalCommand = config.remoteBashCommand?.ifBlank { null }?.let { "&& $it" } ?: ""
         val remoteGradleCommand = "./gradlew -P$BUILD_ON_REMOTE=true $taskArgs"
-        val remoteBashCommand = "echo 'set -e $additionalCommand && cd \"$remoteFolder\" && $remoteGradleCommand' | bash"
+        val remoteBashCommand = "echo 'set -e $additionalCommand && cd $remoteFolder && $remoteGradleCommand' | bash"
 
         setCommandLine(config.sshClient)
         args(config.sshArgs)


### PR DESCRIPTION
### Summary
- Fix hostname replacement error
- Fix korean function name borken error

### Description

#### Fix hostname replacement error
A problem occurs when the local and remote home account names are different.
Because of the quotation marks, the local home name is being assigned.
For example,
```
// local : /home/smith
// remote : /home/john

$ ssh mainframer "echo '~/mirakle/myproject'"
/home/smith/mirakle/myproject             // <- it happens in 1.5.2 and occurs NotFoundException

$ ssh mainframer "echo ~/mirakle/myproject"
/home/john/mirakle/myproject               // <- this is what we want
```
So I remove quotes at https://github.com/Adambl4/mirakle/commit/779c3a7192f93a2eddae8c45f7589cecc9edebdc

#### Fix korean function name borken error
If I make the function name in Korean, it brokes in the console like below.
<img width="748" alt="스크린샷 2022-08-15 오후 3 24 25" src="https://user-images.githubusercontent.com/5474864/184586611-e4316cdc-aa8b-43e3-a756-7dae58bf211f.png">
It also happens bash, zsh, IDE terminal.
The test result(*.html, *.xml) is created and downloaded as utf-8, but utf-8 is not applied to the ssh script.
So I append encoding envirnment at https://github.com/Adambl4/mirakle/commit/779c3a7192f93a2eddae8c45f7589cecc9edebdc.

### Related
- https://github.com/Adambl4/mirakle/pull/111