### PR TITLE
fix for windows: cygwin rsync breaks project directory on a remote machine

### DIFF
--- a/plugin/src/main/kotlin/Mirakle.kt
+++ b/plugin/src/main/kotlin/Mirakle.kt
@@ -393,6 +393,7 @@ open class ExecuteOnRemoteTask : Exec() {
         val additionalCommand = config.remoteBashCommand?.ifBlank { null }
         val remoteGradleCommand = "./gradlew -P$BUILD_ON_REMOTE=true $taskArgs"
         val remoteBashCommand = listOfNotNull(
+            "setfacl -b -R $remoteFolder",
             "set -e",
             additionalCommand,
             "export LANG=C.UTF-8",


### PR DESCRIPTION
**What problem does it solve?**

I tested Mirakle plugin on a Windows 10 laptop and discovered a weird thing. Rsync implementation from Cygwin works fine, however for some reason in some cases (not 100% sure, but it started from certain gradle update, some old project can be build fine, others, newer - can't) after all files from the directory with project source code was successfully transferred to the similar directory on the server, that directory receives certain ACL rules that applied to the directory. Those ACL rules limit the file permission mask for any newly created files in that directory to the value of 070, which make those files effectively inaccessible the user that owns them and gradle process cannot access them, the build is crushed with an error "cannot open file".

**Solution:**

I have added another command to executeOnRemote gradle task. It just deletes any previously set ACL rules from the project directory. If there are none of them in case of older gradle versions or you use Mirakle on Linux or MacOS - then nothing will happen.

The command is:
```
setfacl -b -R $remoteFolder
```
NOTE! The setfacl binary is not present in all Linux distros by default. So you will have to make sure it exists on the remote system before running Mirakle builds from a Windows machine. The binary can be easily installed with this command (this have to be done just once):
```
sudo apt install acl -y
```